### PR TITLE
Grant access to Icy{In,Ext}ernalFrame.updateTitlePane()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.class
+setting.xml
+
+workspace/sys.xml

--- a/icy/gui/frame/IcyExternalFrame.java
+++ b/icy/gui/frame/IcyExternalFrame.java
@@ -81,11 +81,9 @@ public class IcyExternalFrame extends JFrame implements SkinChangeListener
         // JFrame doesn't have updateUI() method so we have to listen LAF skin change
         LookAndFeelUtil.addSkinChangeListener(this);
     }
-
-    private void updateTitlePane()
+    
+    protected void updateTitlePane(final SubstanceTitlePane pane)
     {
-        final SubstanceTitlePane pane = LookAndFeelUtil.getTitlePane(this);
-
         // update pane save
         if (pane != null)
         {
@@ -109,6 +107,12 @@ public class IcyExternalFrame extends JFrame implements SkinChangeListener
 
         // refresh system menu
         updateSystemMenu();
+    	
+    }
+    
+    protected void updateTitlePane()
+    {
+        updateTitlePane(LookAndFeelUtil.getTitlePane(this));
     }
 
     /**

--- a/icy/gui/frame/IcyInternalFrame.java
+++ b/icy/gui/frame/IcyInternalFrame.java
@@ -112,11 +112,9 @@ public class IcyInternalFrame extends JInternalFrame
         titleBarVisible = true;
         initialized = true;
     }
-
-    private void updateTitlePane()
+    
+    protected void updateTitlePane(final SubstanceInternalFrameTitlePane pane)
     {
-        final SubstanceInternalFrameTitlePane pane = LookAndFeelUtil.getTitlePane(this);
-
         // update pane save
         if (pane != null)
         {
@@ -147,6 +145,11 @@ public class IcyInternalFrame extends JInternalFrame
 
         // refresh system menu whatever
         updateSystemMenu();
+    }
+    
+    protected void updateTitlePane()
+    {
+        updateTitlePane(LookAndFeelUtil.getTitlePane(this));
     }
 
     /**

--- a/setting.xml
+++ b/setting.xml
@@ -60,13 +60,13 @@
 <key name="nbFile" value="0"/>
 </section>
 </section>
-<key name="os" value="win64"/>
+<key name="os" value="mac64"/>
 </section>
 <section name="plugins"/>
 <section name="frame">
 <section name="main">
 <key name="XE" value="104"/>
-<key name="YE" value="94"/>
+<key name="YE" value="321"/>
 <key name="WidthE" value="952"/>
 <key name="HeightE" value="672"/>
 <key name="MinimizedE" value="false"/>


### PR DESCRIPTION
this allows plugins to override substance's title pane.
(also added a .gitignore file to avoid committing local user files in the future)
