### PR TITLE
Bicubic interpolation for the 2D canvas

### DIFF
--- a/icy/canvas/Canvas2D.java
+++ b/icy/canvas/Canvas2D.java
@@ -1305,6 +1305,20 @@ public class Canvas2D extends IcyCanvas2D implements ToolRibbonTaskListener
             {
                 final Graphics2D g2 = (Graphics2D) g.create();
 
+                if (getTransform().getScaleX() < 4. && getTransform().getScaleX() < 4.) {
+	                if (!transform.isMoving()) {
+	                	// Draw the image with bicubic resampling,
+	                	// except when zoom is larger than 400 %, where nearest-neighbour is desirable
+	                	// (so that the user can see that he is operating on pixels),
+	                	// and except during the zooming animation, when speed must be high.
+	                	// TODO: when the zoom factor is smaller than 1, a low-pass filter should be applied
+	                	// before the sampling, otherwise severe aliasing is introduced.
+	                	g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);	
+	                } else {
+	                	g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+	                }
+                }
+                
                 g2.transform(getTransform());
                 g2.drawImage(img, null, 0, 0);
 


### PR DESCRIPTION
This patch asks Java to use bucubic interpolation for the affine transformation in the 2D canvas. This dramatically improves the display of images when the zoom factor is different from 100%, or when there is some rotation applied. The improvement is very noticeable in images subject to aliasing, such as "barbara", with all the small lines...
