### PR TITLE
fixed MainInterface.getInternalFrames() throwing ClassCastException

### DIFF
--- a/icy/gui/main/MainFrame.java
+++ b/icy/gui/main/MainFrame.java
@@ -318,7 +318,7 @@ public class MainFrame extends JRibbonFrame
     public ArrayList<JInternalFrame> getInternalFrames()
     {
         if (desktopPane != null)
-            return (ArrayList<JInternalFrame>) Arrays.asList(desktopPane.getAllFrames());
+            return new ArrayList<JInternalFrame>(Arrays.asList(desktopPane.getAllFrames()));
 
         return new ArrayList<JInternalFrame>();
     }


### PR DESCRIPTION
the MainInterface has the following two methods:
- getExternalFrames() returning a java.util.ArrayList<JFrame>
- getInternalFrames() returning a java.util.ArrayList<JInternalFrame>

Problem: the second method casts a java.util.Arrays$ArrayList class into a java.util.ArrayList class, and these two classes are not compatible (cannot be cast to one another). Therefore this method cannot work and always throws a ClassCastException.
