### PR TITLE
Filtering in Canvas2D and CanvasMap

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -11,6 +11,7 @@
 	<classpathentry kind="lib" path="/Icy-App/lib/jai_codec.jar"/>
 	<classpathentry kind="lib" path="/Icy-App/lib/jai_core.jar"/>
 	<classpathentry kind="lib" path="/Icy-App/lib/Jama.jar"/>
+        <classpathentry kind="lib" path="/Icy-App/lib/java-image-scaling.jar"/>
 	<classpathentry kind="lib" path="/Icy-App/lib/javacl.jar"/>
 	<classpathentry kind="lib" path="/Icy-App/lib/jcl-core.jar" sourcepath="/Users/stephane/git/JCL"/>
 	<classpathentry kind="lib" path="/Icy-App/lib/jcommon.jar"/>

--- a/icy/canvas/Canvas2D.java
+++ b/icy/canvas/Canvas2D.java
@@ -1337,11 +1337,13 @@ public class Canvas2D extends IcyCanvas2D implements ToolRibbonTaskListener
                             g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
                                     RenderingHints.VALUE_INTERPOLATION_BICUBIC);
 
-                            // downsample the image before displaying it
-                            ResampleOp resampleOp = new ResampleOp (getDestImageCanvasSizeX(), getDestImageCanvasSizeY());
-                            img = resampleOp.filter(img, null);
-                            // the scale transformation is no longer needed
-                            imgTransform.scale(1./getScaleX(), 1./getScaleY());
+                            if (getScaleX() < 1d && getScaleY() < 1d) {
+	                            // downsample the image before displaying it
+	                            ResampleOp resampleOp = new ResampleOp (getDestImageCanvasSizeX(), getDestImageCanvasSizeY());
+	                            img = resampleOp.filter(img, null);
+	                            // the scale transformation is no longer needed
+	                            imgTransform.scale(1./getScaleX(), 1./getScaleY());
+                            }
                     	}
                     }
                     else

--- a/icy/canvas/Canvas2D.java
+++ b/icy/canvas/Canvas2D.java
@@ -543,8 +543,15 @@ public class Canvas2D extends IcyCanvas2D implements ToolRibbonTaskListener
                 final Graphics2D g2 = (Graphics2D) g.create();
                 final BufferedImage img = canvasView.imageCache.getImage();
 
+                // downsample the image before displaying it
+                AffineTransform imgTrans = (AffineTransform) trans.clone();      
+                ResampleOp resampleOp = new ResampleOp ((int) (img.getWidth()*imgTrans.getScaleX()), (int) (img.getHeight()*imgTrans.getScaleY()));
+                imgTrans.scale(1./imgTrans.getScaleX(), 1./imgTrans.getScaleY());
+                // use bicubic interpolation for better-looking image
+                g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+                		RenderingHints.VALUE_INTERPOLATION_BICUBIC);
                 // draw image
-                g2.drawImage(img, trans, null);
+                g2.drawImage(resampleOp.filter(img, null), imgTrans, null);
 
                 // then apply canvas inverse transformation
                 trans.scale(1 / getScaleX(), 1 / getScaleY());

--- a/icy/canvas/Canvas2D.java
+++ b/icy/canvas/Canvas2D.java
@@ -1314,7 +1314,7 @@ public class Canvas2D extends IcyCanvas2D implements ToolRibbonTaskListener
 
                 if (CanvasPreferences.getFiltering())
                 {
-                    if (getScaleX() < 4d && getScaleY() < 4d)
+                    if (getScaleX() < 3d && getScaleY() < 3d)
                     {
                     	if (transform.isMoving())
                     	{

--- a/icy/canvas/Canvas2D.java
+++ b/icy/canvas/Canvas2D.java
@@ -1313,8 +1313,20 @@ public class Canvas2D extends IcyCanvas2D implements ToolRibbonTaskListener
                 {
                     if (getScaleX() < 4d && getScaleY() < 4d)
                     {
-                        g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
-                                RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+                    	if (transform.isMoving())
+                    	{
+                    		// when the view is moving, draw with a fast bilinear
+                    		// interpolation
+                            g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+                                    RenderingHints.VALUE_INTERPOLATION_BILINEAR);                    		
+                    	}
+                    	else
+                    	{
+                    		// when the view is static, draw with a better-looking
+                    		// bicubic interpolation
+                            g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+                                    RenderingHints.VALUE_INTERPOLATION_BICUBIC);                    		
+                    	}
                     }
                     else
                     {


### PR DESCRIPTION
Dear Icy masters,

Here is a pull request for filtering in canvas2d and canvasMap.

-Commit 629c5b27 enables bicubic interpolation on the canvas when the view is not moving.

-Commut 652ebf3d reduces the scale limit between nearest-neighbour and bicubic. Before, NR was used when the scale is larger than 400%. It is now used when the scale is larger than 300%. I find it clearer.

-Commits 83e1991d and 242ae87d add a downsampling step when the scale is smaller than 1. This removes aliasing artefacts. The downsampling is a high-quality Lanczos3 filter provided by a library named java-image-scaling. The correspoding jar has to be added to the build path ! It can be downloaded from there: http://code.google.com/p/java-image-scaling/
- Finally, commit 20da8983 enables the downsampling filter and the bicubic interpolation on the CanvasMap. I think it looks much nicer...

What do you think  about these modifications ?

Timothée
