### PR TITLE
Draw the colormap with a polyline --> antialiasing

### DIFF
--- a/icy/image/colormap/IcyColorMapBand.java
+++ b/icy/image/colormap/IcyColorMapBand.java
@@ -721,6 +721,15 @@ public class IcyColorMapBand implements XMLPersistent
     {
         return updateCnt > 0;
     }
+    
+    /**
+     * returns true when the LUT is specified by raw data (for example GIF files),
+     * false when the LUT is specified by control points.
+     */
+    public boolean isRawData()
+    {
+    	return rawData;
+    }
 
     @Override
     public boolean loadFromXML(Node node)


### PR DESCRIPTION
Currently the LUT lines are drawn with sequences of one pixel lines. This patch
replaces that by polylines that go through all control points. I think polyline are faster, and more
importantly, it produces nice antialiased lines !

Here is the result:

![Imgur](http://i.imgur.com/IzMxb.png)

The code also adds a getter for the rawData property in IcyColorMapBand, and fixes the copy of that parameter when copying from another colorMap.
