### PR TITLE
How about adding popup menu for each plugin icon to show opened frames

### DIFF
--- a/icy/gui/plugin/PluginCommandButton.java
+++ b/icy/gui/plugin/PluginCommandButton.java
@@ -184,16 +184,16 @@ public class PluginCommandButton
             			 @Override
                          public void actionPerformed(ActionEvent e)
                          {
-            				 
-            				 while(true){
-            					 if(Plugin.openedFramesMap.containsKey(plugin.getClassName())){
-            						 synchronized (Plugin.openedFramesMap.get(plugin.getClassName()))
+            				 if(Plugin.openedFramesMap.containsKey(plugin.getClassName()))
+            				 {
+            					 synchronized (Plugin.openedFramesMap.get(plugin.getClassName()))
+            					 {
+            						 for(int i=0;i<Plugin.openedFramesMap.get(plugin.getClassName()).size();i++)
             						 {
-            							 Plugin.openedFramesMap.get(plugin.getClassName()).get(0).close();
-            						 }
-            					 }	
-            					 else
-            						 break;
+	            					 
+	            						Plugin.openedFramesMap.get(plugin.getClassName()).get(i).close();
+	            					 }
+	            				 }
             				 }
                          }
             		});

--- a/icy/gui/plugin/PluginCommandButton.java
+++ b/icy/gui/plugin/PluginCommandButton.java
@@ -188,10 +188,10 @@ public class PluginCommandButton
             				 {
             					 synchronized (Plugin.openedFramesMap.get(plugin.getClassName()))
             					 {
-            						 for(int i=0;i<Plugin.openedFramesMap.get(plugin.getClassName()).size();i++)
+            						 int count = Plugin.openedFramesMap.get(plugin.getClassName()).size();
+            						 for(int i=0;i<count;i++)
             						 {
-	            					 
-	            						Plugin.openedFramesMap.get(plugin.getClassName()).get(i).close();
+	            						Plugin.openedFramesMap.get(plugin.getClassName()).get(0).close();
 	            					 }
 	            				 }
             				 }

--- a/icy/gui/plugin/PluginCommandButton.java
+++ b/icy/gui/plugin/PluginCommandButton.java
@@ -20,17 +20,30 @@ package icy.gui.plugin;
 
 import icy.gui.component.button.IcyCommandButton;
 import icy.gui.component.button.IcyCommandToggleButton;
+import icy.gui.frame.IcyFrame;
 import icy.plugin.PluginDescriptor;
 import icy.plugin.PluginLauncher;
 import icy.plugin.PluginLoader;
+import icy.plugin.abstract_.Plugin;
 import icy.resource.icon.BasicResizableIcon;
+import icy.system.thread.ThreadUtil;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
 
 import javax.swing.ImageIcon;
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
 
 import org.pushingpixels.flamingo.api.common.AbstractCommandButton;
+import org.pushingpixels.flamingo.api.common.JCommandButton;
+import org.pushingpixels.flamingo.api.common.RichTooltip;
+import org.pushingpixels.flamingo.api.common.JCommandButton.CommandButtonKind;
+import org.pushingpixels.flamingo.api.common.popup.JPopupPanel;
+import org.pushingpixels.flamingo.api.common.popup.PopupPanelCallback;
 
 /**
  * Class helper to create plugin command button
@@ -42,12 +55,13 @@ public class PluginCommandButton
     /**
      * Set a plugin button with specified action
      */
-    public static void setButton(AbstractCommandButton button, PluginDescriptor plugin, boolean doAction)
+    public static void setButton(AbstractCommandButton button, final PluginDescriptor plugin, boolean doAction)
     {
         final String name = plugin.getName();
         final String className = plugin.getClassName();
         final ImageIcon plugIcon = plugin.getIcon();
-
+        
+        
         // update text & icon
         button.setText(name);
         button.setIcon(new BasicResizableIcon(plugIcon));
@@ -75,7 +89,120 @@ public class PluginCommandButton
                         PluginLauncher.start(plugin);
                 }
             });
+           
+            if(button.getClass().equals(IcyCommandButton.class))
+            {
+	            final IcyCommandButton btn =(IcyCommandButton) button;
+	            btn.addMouseListener(new MouseListener(){
+					@Override
+					public void mouseClicked(MouseEvent arg0) {
+						updateSubmenu(btn,plugin);
+					}
+	
+					@Override
+					public void mouseEntered(MouseEvent arg0) {
+						updateSubmenu(btn,plugin);
+					}
+					@Override
+					public void mouseExited(MouseEvent arg0) {
+						btn.setCommandButtonKind(CommandButtonKind.ACTION_ONLY);
+						
+					}
+	
+					@Override
+					public void mousePressed(MouseEvent arg0) {
+						
+					}
+	
+					@Override
+					public void mouseReleased(MouseEvent arg0) {
+						
+					}
+	            	
+	            });
+            }
         }
+    }
+    /**
+     * Update the popup menu of current command button
+     */
+    public static void updateSubmenu(final IcyCommandButton btn, final PluginDescriptor plugin)
+    {
+    	if(Plugin.openedFramesMap.containsKey(plugin))
+		{
+	        btn.setCommandButtonKind(CommandButtonKind.POPUP_ONLY);
+	        btn.setPopupRichTooltip(new PluginRichToolTip(plugin));
+	        btn.setPopupCallback(new PopupPanelCallback()
+	        {
+	            @Override
+	            public JPopupPanel getPopupPanel(JCommandButton commandButton)
+	            {
+	            	final JMenu framesOfPluginMenu = new JMenu("Opened frames");
+	            	final JMenuItem newInstanceItem = new JMenuItem("New Instance");
+	            	newInstanceItem.addActionListener(new ActionListener(){
+            			 @Override
+                         public void actionPerformed(ActionEvent e)
+                         {
+            				 btn.doActionClick();
+                         }
+            		});
+	            	framesOfPluginMenu.add(newInstanceItem);
+	            	framesOfPluginMenu.addSeparator();
+	            	for(final IcyFrame f : Plugin.openedFramesMap.get(plugin)){
+	            		final JMenuItem frameItem = new JMenuItem(f.getTitle());
+	            		frameItem.addActionListener(new ActionListener()
+	                    {
+	            			 @Override
+                             public void actionPerformed(ActionEvent e)
+                             {
+                                 ThreadUtil.invokeLater(new Runnable()
+                                 {
+                                     @Override
+                                     public void run()
+                                     {
+                                         // remove minimized state
+                                         if (f.isMinimized())
+                                             f.setMinimized(false);
+                                         // then grab focus
+                                         f.requestFocus();
+                                         f.toFront();
+                                     }
+                                 });
+                             }
+	                    });
+	                    framesOfPluginMenu.add(frameItem);
+	            	}
+	            	framesOfPluginMenu.addSeparator();
+	            	// close all menu item
+	            	final JMenuItem closeAllItem = new JMenuItem("Close All");
+	            	closeAllItem.addActionListener(new ActionListener(){
+            			 @Override
+                         public void actionPerformed(ActionEvent e)
+                         {
+            				 while(true){
+            					 if(Plugin.openedFramesMap.containsKey(plugin)){
+	            					 Plugin.openedFramesMap.get(plugin).get(0).close(); 
+            					 }	
+            					 else
+            						 break;
+            				 }
+                         }
+            		});
+	            	framesOfPluginMenu.add(closeAllItem);
+	            	
+	                final JPopupMenu popupMenu = framesOfPluginMenu.getPopupMenu();
+	                
+	                // FIXME : set as heavy weight component for VTK (doesn't work)
+	                // popupMenu.setLightWeightPopupEnabled(false);
+	                popupMenu.show(btn, 0, btn.getHeight());
+	
+	                return null;
+	            }
+	        });
+	       
+		}
+		else
+			btn.setCommandButtonKind(CommandButtonKind.ACTION_ONLY);
     }
 
     /**
@@ -89,7 +216,7 @@ public class PluginCommandButton
     /**
      * Build a plugin button
      */
-    public static AbstractCommandButton createButton(PluginDescriptor plugin, boolean toggle, boolean doAction)
+    public static AbstractCommandButton createButton(final PluginDescriptor plugin, boolean toggle, boolean doAction)
     {
         final AbstractCommandButton result;
 
@@ -97,8 +224,10 @@ public class PluginCommandButton
         if (toggle)
             result = new IcyCommandToggleButton();
         else
-            result = new IcyCommandButton();
-
+        {
+	        result = new IcyCommandButton();
+        }
+        
         setButton(result, plugin, doAction);
 
         return result;

--- a/icy/plugin/PluginLauncher.java
+++ b/icy/plugin/PluginLauncher.java
@@ -53,6 +53,10 @@ public class PluginLauncher implements Runnable
             @Override
             public void run()
             {
+            	//backup the thread name
+            	String threadName = Thread.currentThread().getName();
+            	//transfer the descriptor name to icyframe
+            	Thread.currentThread().setName(descriptor.getClassName());
                 try
                 {
                     plugin = descriptor.getPluginClass().newInstance();
@@ -62,6 +66,8 @@ public class PluginLauncher implements Runnable
                     plugin = null;
                     IcyExceptionHandler.handleException(descriptor, t, true);
                 }
+                //recover the thread name
+                Thread.currentThread().setName(threadName);
             }
         });
     }
@@ -69,6 +75,10 @@ public class PluginLauncher implements Runnable
     @Override
     public void run()
     {
+    	//backup the thread name
+    	String threadName = Thread.currentThread().getName();
+    	//transfer the descriptor name to icyframe
+    	Thread.currentThread().setName(descriptor.getClassName());
         try
         {
             // keep backward compatibility
@@ -79,6 +89,8 @@ public class PluginLauncher implements Runnable
         {
             IcyExceptionHandler.handleException(descriptor, t, true);
         }
+        //recover the thread name
+        Thread.currentThread().setName(threadName);
     }
 
     /**
@@ -89,10 +101,10 @@ public class PluginLauncher implements Runnable
         final Thread thread;
 
         if (plugin instanceof PluginThreaded)
-            thread = new Thread((PluginThreaded) plugin, descriptor.getName());
+            thread = new Thread((PluginThreaded) plugin, descriptor.getClassName());
         // keep backward compatibility
         else if (plugin instanceof PluginStartAsThread)
-            thread = new Thread(this, descriptor.getName());
+            thread = new Thread(this, descriptor.getClassName());
         else
             thread = null;
 
@@ -100,8 +112,10 @@ public class PluginLauncher implements Runnable
         if (thread != null)
             thread.start();
         else
+        {
             // direct launch in EDT now (no thread creation)
             ThreadUtil.invokeNow(this);
+        }
     }
 
     /**

--- a/icy/plugin/abstract_/Plugin.java
+++ b/icy/plugin/abstract_/Plugin.java
@@ -20,6 +20,8 @@ package icy.plugin.abstract_;
 
 import icy.file.FileUtil;
 import icy.gui.frame.IcyFrame;
+import icy.gui.frame.IcyFrameAdapter;
+import icy.gui.frame.IcyFrameEvent;
 import icy.gui.viewer.Viewer;
 import icy.image.IcyBufferedImage;
 import icy.image.ImageUtil;
@@ -41,6 +43,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.HashMap;
 
 import javax.swing.ImageIcon;
 
@@ -53,6 +56,7 @@ import javax.swing.ImageIcon;
  */
 public abstract class Plugin
 {
+	
     public static Plugin getPlugin(ArrayList<Plugin> list, String className)
     {
         for (Plugin plugin : list)
@@ -62,6 +66,7 @@ public abstract class Plugin
         return null;
     }
 
+    public static HashMap<PluginDescriptor, ArrayList<IcyFrame>> openedFramesMap = new HashMap<PluginDescriptor, ArrayList<IcyFrame>>();
     private final PluginDescriptor descriptor;
 
     public Plugin()
@@ -139,6 +144,31 @@ public abstract class Plugin
 
     public void addIcyFrame(final IcyFrame frame)
     {
+    	//Add the frame to openedFrameMap for popup menu generation
+    	//FIXME: Not all plugin add frame use this function
+    	if(openedFramesMap.containsKey(descriptor)){
+    		openedFramesMap.get(descriptor).add(frame);
+    	}
+    	else{
+    		ArrayList<IcyFrame> fl = new ArrayList<IcyFrame>();
+    		fl.add(frame);
+    		openedFramesMap.put(descriptor, fl);
+    	}	
+    	frame.addFrameListener(new IcyFrameAdapter()
+        {
+            // called when frame is closed
+            @Override
+            public void icyFrameClosed(IcyFrameEvent e)
+            {
+    	    	if(openedFramesMap.containsKey(descriptor)){
+		    		openedFramesMap.get(descriptor).remove(frame);
+		    		//remove the empty item
+		    		if(openedFramesMap.get(descriptor).size()<=0)
+		    			openedFramesMap.remove(descriptor);
+		    	}
+            }
+        });
+    	
         frame.addToMainDesktopPane();
     }
 

--- a/icy/plugin/abstract_/Plugin.java
+++ b/icy/plugin/abstract_/Plugin.java
@@ -20,8 +20,6 @@ package icy.plugin.abstract_;
 
 import icy.file.FileUtil;
 import icy.gui.frame.IcyFrame;
-import icy.gui.frame.IcyFrameAdapter;
-import icy.gui.frame.IcyFrameEvent;
 import icy.gui.viewer.Viewer;
 import icy.image.IcyBufferedImage;
 import icy.image.ImageUtil;
@@ -62,11 +60,11 @@ public abstract class Plugin
         for (Plugin plugin : list)
             if (plugin.getClass().getName().equals(className))
                 return plugin;
-
         return null;
     }
 
-    public static HashMap<PluginDescriptor, ArrayList<IcyFrame>> openedFramesMap = new HashMap<PluginDescriptor, ArrayList<IcyFrame>>();
+    //set to final field enables safely read through non-synchronized methods
+    public final static HashMap<String, ArrayList<IcyFrame>> openedFramesMap = new HashMap<String, ArrayList<IcyFrame>>();
     private final PluginDescriptor descriptor;
 
     public Plugin()
@@ -145,30 +143,6 @@ public abstract class Plugin
     public void addIcyFrame(final IcyFrame frame)
     {
     	//Add the frame to openedFrameMap for popup menu generation
-    	//FIXME: Not all plugin add frame use this function
-    	if(openedFramesMap.containsKey(descriptor)){
-    		openedFramesMap.get(descriptor).add(frame);
-    	}
-    	else{
-    		ArrayList<IcyFrame> fl = new ArrayList<IcyFrame>();
-    		fl.add(frame);
-    		openedFramesMap.put(descriptor, fl);
-    	}	
-    	frame.addFrameListener(new IcyFrameAdapter()
-        {
-            // called when frame is closed
-            @Override
-            public void icyFrameClosed(IcyFrameEvent e)
-            {
-    	    	if(openedFramesMap.containsKey(descriptor)){
-		    		openedFramesMap.get(descriptor).remove(frame);
-		    		//remove the empty item
-		    		if(openedFramesMap.get(descriptor).size()<=0)
-		    			openedFramesMap.remove(descriptor);
-		    	}
-            }
-        });
-    	
         frame.addToMainDesktopPane();
     }
 


### PR DESCRIPTION
Hi masters,

I am thinking about add popup menu for plugin icon, the following aspect are taken into account:
1. Too much frames will mess the work area, especially in "Multiple document interface" mode and a computer with a small screen. Frames will hide under some other frames, especially for some small-sized frame.
2. When one of the frame is in maximized mode, other frame will be totally invisible for user, in this situation, a quick operation for a plugin is open a new instance, but if you click on the sequence,the new frame will hide too.
3. Most plugin have a "input sequence" like option and usually use "Active Sequence" as default value, this option enables the plugin works in single-instance mode in most situation.
4. Although we can get all opened frame in the toolbar, but I think the most intuitive way to get the opened frame of a plugin is to start it from the plugin icon.

So I add some test code to demonstrate my solution to this problem, I spend several hours to get familiar with Icy-Kernel code, and try to add my code in a elegant way as you guys do, but I still can't find a elegant way to do it. Eventually, it works like this:

![1](https://f.cloud.github.com/assets/478667/1415496/1a0292f2-3f08-11e3-8622-28cceafbeb38.png)

A little ugly, but maybe useful. 
As you can see, current version only works with some plugins.To be exactly, all plugins use "addIcyFrame()" will work. I haven't find a reliable method to hook all IcyFrame for each plugin. Suggestions will be appreciated.

 I hope you can think about it.

Best,
Will Ouyang