### PR TITLE
Add native script-plugin support to Icy to build plugins with Javascript, Python, R, and etc.

### DIFF
--- a/icy/gui/plugin/PluginCommandButton.java
+++ b/icy/gui/plugin/PluginCommandButton.java
@@ -184,16 +184,16 @@ public class PluginCommandButton
             			 @Override
                          public void actionPerformed(ActionEvent e)
                          {
-            				 
-            				 while(true){
-            					 if(Plugin.openedFramesMap.containsKey(plugin.getClassName())){
-            						 synchronized (Plugin.openedFramesMap.get(plugin.getClassName()))
+            				 if(Plugin.openedFramesMap.containsKey(plugin.getClassName()))
+            				 {
+            					 synchronized (Plugin.openedFramesMap.get(plugin.getClassName()))
+            					 {
+            						 for(int i=0;i<Plugin.openedFramesMap.get(plugin.getClassName()).size();i++)
             						 {
-            							 Plugin.openedFramesMap.get(plugin.getClassName()).get(0).close();
-            						 }
-            					 }	
-            					 else
-            						 break;
+	            					 
+	            						Plugin.openedFramesMap.get(plugin.getClassName()).get(i).close();
+	            					 }
+	            				 }
             				 }
                          }
             		});

--- a/icy/gui/plugin/PluginCommandButton.java
+++ b/icy/gui/plugin/PluginCommandButton.java
@@ -188,10 +188,10 @@ public class PluginCommandButton
             				 {
             					 synchronized (Plugin.openedFramesMap.get(plugin.getClassName()))
             					 {
-            						 for(int i=0;i<Plugin.openedFramesMap.get(plugin.getClassName()).size();i++)
+            						 int count = Plugin.openedFramesMap.get(plugin.getClassName()).size();
+            						 for(int i=0;i<count;i++)
             						 {
-	            					 
-	            						Plugin.openedFramesMap.get(plugin.getClassName()).get(i).close();
+	            						Plugin.openedFramesMap.get(plugin.getClassName()).get(0).close();
 	            					 }
 	            				 }
             				 }

--- a/icy/gui/plugin/PluginCommandButton.java
+++ b/icy/gui/plugin/PluginCommandButton.java
@@ -20,17 +20,30 @@ package icy.gui.plugin;
 
 import icy.gui.component.button.IcyCommandButton;
 import icy.gui.component.button.IcyCommandToggleButton;
+import icy.gui.frame.IcyFrame;
 import icy.plugin.PluginDescriptor;
 import icy.plugin.PluginLauncher;
 import icy.plugin.PluginLoader;
+import icy.plugin.abstract_.Plugin;
 import icy.resource.icon.BasicResizableIcon;
+import icy.system.thread.ThreadUtil;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
 
 import javax.swing.ImageIcon;
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
 
 import org.pushingpixels.flamingo.api.common.AbstractCommandButton;
+import org.pushingpixels.flamingo.api.common.JCommandButton;
+import org.pushingpixels.flamingo.api.common.RichTooltip;
+import org.pushingpixels.flamingo.api.common.JCommandButton.CommandButtonKind;
+import org.pushingpixels.flamingo.api.common.popup.JPopupPanel;
+import org.pushingpixels.flamingo.api.common.popup.PopupPanelCallback;
 
 /**
  * Class helper to create plugin command button
@@ -42,12 +55,13 @@ public class PluginCommandButton
     /**
      * Set a plugin button with specified action
      */
-    public static void setButton(AbstractCommandButton button, PluginDescriptor plugin, boolean doAction)
+    public static void setButton(AbstractCommandButton button, final PluginDescriptor plugin, boolean doAction)
     {
         final String name = plugin.getName();
         final String className = plugin.getClassName();
         final ImageIcon plugIcon = plugin.getIcon();
-
+        
+        
         // update text & icon
         button.setText(name);
         button.setIcon(new BasicResizableIcon(plugIcon));
@@ -75,7 +89,120 @@ public class PluginCommandButton
                         PluginLauncher.start(plugin);
                 }
             });
+           
+            if(button.getClass().equals(IcyCommandButton.class))
+            {
+	            final IcyCommandButton btn =(IcyCommandButton) button;
+	            btn.addMouseListener(new MouseListener(){
+					@Override
+					public void mouseClicked(MouseEvent arg0) {
+						updateSubmenu(btn,plugin);
+					}
+	
+					@Override
+					public void mouseEntered(MouseEvent arg0) {
+						updateSubmenu(btn,plugin);
+					}
+					@Override
+					public void mouseExited(MouseEvent arg0) {
+						btn.setCommandButtonKind(CommandButtonKind.ACTION_ONLY);
+						
+					}
+	
+					@Override
+					public void mousePressed(MouseEvent arg0) {
+						
+					}
+	
+					@Override
+					public void mouseReleased(MouseEvent arg0) {
+						
+					}
+	            	
+	            });
+            }
         }
+    }
+    /**
+     * Update the popup menu of current command button
+     */
+    public static void updateSubmenu(final IcyCommandButton btn, final PluginDescriptor plugin)
+    {
+    	if(Plugin.openedFramesMap.containsKey(plugin))
+		{
+	        btn.setCommandButtonKind(CommandButtonKind.POPUP_ONLY);
+	        btn.setPopupRichTooltip(new PluginRichToolTip(plugin));
+	        btn.setPopupCallback(new PopupPanelCallback()
+	        {
+	            @Override
+	            public JPopupPanel getPopupPanel(JCommandButton commandButton)
+	            {
+	            	final JMenu framesOfPluginMenu = new JMenu("Opened frames");
+	            	final JMenuItem newInstanceItem = new JMenuItem("New Instance");
+	            	newInstanceItem.addActionListener(new ActionListener(){
+            			 @Override
+                         public void actionPerformed(ActionEvent e)
+                         {
+            				 btn.doActionClick();
+                         }
+            		});
+	            	framesOfPluginMenu.add(newInstanceItem);
+	            	framesOfPluginMenu.addSeparator();
+	            	for(final IcyFrame f : Plugin.openedFramesMap.get(plugin)){
+	            		final JMenuItem frameItem = new JMenuItem(f.getTitle());
+	            		frameItem.addActionListener(new ActionListener()
+	                    {
+	            			 @Override
+                             public void actionPerformed(ActionEvent e)
+                             {
+                                 ThreadUtil.invokeLater(new Runnable()
+                                 {
+                                     @Override
+                                     public void run()
+                                     {
+                                         // remove minimized state
+                                         if (f.isMinimized())
+                                             f.setMinimized(false);
+                                         // then grab focus
+                                         f.requestFocus();
+                                         f.toFront();
+                                     }
+                                 });
+                             }
+	                    });
+	                    framesOfPluginMenu.add(frameItem);
+	            	}
+	            	framesOfPluginMenu.addSeparator();
+	            	// close all menu item
+	            	final JMenuItem closeAllItem = new JMenuItem("Close All");
+	            	closeAllItem.addActionListener(new ActionListener(){
+            			 @Override
+                         public void actionPerformed(ActionEvent e)
+                         {
+            				 while(true){
+            					 if(Plugin.openedFramesMap.containsKey(plugin)){
+	            					 Plugin.openedFramesMap.get(plugin).get(0).close(); 
+            					 }	
+            					 else
+            						 break;
+            				 }
+                         }
+            		});
+	            	framesOfPluginMenu.add(closeAllItem);
+	            	
+	                final JPopupMenu popupMenu = framesOfPluginMenu.getPopupMenu();
+	                
+	                // FIXME : set as heavy weight component for VTK (doesn't work)
+	                // popupMenu.setLightWeightPopupEnabled(false);
+	                popupMenu.show(btn, 0, btn.getHeight());
+	
+	                return null;
+	            }
+	        });
+	       
+		}
+		else
+			btn.setCommandButtonKind(CommandButtonKind.ACTION_ONLY);
     }
 
     /**
@@ -89,7 +216,7 @@ public class PluginCommandButton
     /**
      * Build a plugin button
      */
-    public static AbstractCommandButton createButton(PluginDescriptor plugin, boolean toggle, boolean doAction)
+    public static AbstractCommandButton createButton(final PluginDescriptor plugin, boolean toggle, boolean doAction)
     {
         final AbstractCommandButton result;
 
@@ -97,8 +224,10 @@ public class PluginCommandButton
         if (toggle)
             result = new IcyCommandToggleButton();
         else
-            result = new IcyCommandButton();
-
+        {
+	        result = new IcyCommandButton();
+        }
+        
         setButton(result, plugin, doAction);
 
         return result;

--- a/icy/plugin/PluginLauncher.java
+++ b/icy/plugin/PluginLauncher.java
@@ -53,6 +53,10 @@ public class PluginLauncher implements Runnable
             @Override
             public void run()
             {
+            	//backup the thread name
+            	String threadName = Thread.currentThread().getName();
+            	//transfer the descriptor name to icyframe
+            	Thread.currentThread().setName(descriptor.getClassName());
                 try
                 {
                     plugin = descriptor.getPluginClass().newInstance();
@@ -62,6 +66,8 @@ public class PluginLauncher implements Runnable
                     plugin = null;
                     IcyExceptionHandler.handleException(descriptor, t, true);
                 }
+                //recover the thread name
+                Thread.currentThread().setName(threadName);
             }
         });
     }
@@ -69,6 +75,10 @@ public class PluginLauncher implements Runnable
     @Override
     public void run()
     {
+    	//backup the thread name
+    	String threadName = Thread.currentThread().getName();
+    	//transfer the descriptor name to icyframe
+    	Thread.currentThread().setName(descriptor.getClassName());
         try
         {
             // keep backward compatibility
@@ -79,6 +89,8 @@ public class PluginLauncher implements Runnable
         {
             IcyExceptionHandler.handleException(descriptor, t, true);
         }
+        //recover the thread name
+        Thread.currentThread().setName(threadName);
     }
 
     /**
@@ -89,10 +101,10 @@ public class PluginLauncher implements Runnable
         final Thread thread;
 
         if (plugin instanceof PluginThreaded)
-            thread = new Thread((PluginThreaded) plugin, descriptor.getName());
+            thread = new Thread((PluginThreaded) plugin, descriptor.getClassName());
         // keep backward compatibility
         else if (plugin instanceof PluginStartAsThread)
-            thread = new Thread(this, descriptor.getName());
+            thread = new Thread(this, descriptor.getClassName());
         else
             thread = null;
 
@@ -100,8 +112,10 @@ public class PluginLauncher implements Runnable
         if (thread != null)
             thread.start();
         else
+        {
             // direct launch in EDT now (no thread creation)
             ThreadUtil.invokeNow(this);
+        }
     }
 
     /**

--- a/icy/plugin/PluginLauncher.java
+++ b/icy/plugin/PluginLauncher.java
@@ -21,6 +21,7 @@ package icy.plugin;
 import icy.main.Icy;
 import icy.plugin.abstract_.Plugin;
 import icy.plugin.interface_.PluginImageAnalysis;
+import icy.plugin.interface_.PluginScriptEngine;
 import icy.plugin.interface_.PluginStartAsThread;
 import icy.plugin.interface_.PluginThreaded;
 import icy.system.IcyExceptionHandler;
@@ -81,8 +82,15 @@ public class PluginLauncher implements Runnable
     	Thread.currentThread().setName(descriptor.getClassName());
         try
         {
+        	if(descriptor.isScriptPlugin())
+        	{
+	            if(plugin instanceof PluginScriptEngine && descriptor.getStartupScript()!=null)
+	            {
+	            	((PluginScriptEngine)plugin).evalFile(descriptor.getStartupScript());
+	            }
+        	}
             // keep backward compatibility
-            if (plugin instanceof PluginImageAnalysis)
+            else if (plugin instanceof PluginImageAnalysis)
                 ((PluginImageAnalysis) plugin).compute();
         }
         catch (Throwable t)

--- a/icy/plugin/PluginLoader.java
+++ b/icy/plugin/PluginLoader.java
@@ -19,6 +19,7 @@
 package icy.plugin;
 
 import icy.common.EventHierarchicalChecker;
+import icy.file.FileUtil;
 import icy.main.Icy;
 import icy.plugin.PluginDescriptor.PluginIdent;
 import icy.plugin.PluginDescriptor.PluginNameSorter;
@@ -26,6 +27,7 @@ import icy.plugin.abstract_.Plugin;
 import icy.plugin.classloader.JarClassLoader;
 import icy.plugin.interface_.PluginBundled;
 import icy.plugin.interface_.PluginDaemon;
+import icy.plugin.interface_.PluginScriptEngine;
 import icy.preferences.PluginPreferences;
 import icy.system.IcyExceptionHandler;
 import icy.system.thread.SingleProcessor;
@@ -33,6 +35,7 @@ import icy.system.thread.ThreadUtil;
 import icy.util.ClassUtil;
 import icy.util.StringUtil;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -327,7 +330,53 @@ public class PluginLoader
                 System.err.println("Class '" + className + "' is discarded");
             }
         }
+        
+	    File pluginsDir = new File(PLUGIN_PATH);
+	    for(File anyfile:FileUtil.getFiles(pluginsDir, null, true, false, true))
+	    {
+	    	try
+	    	{
+	        	//scan the directory with __init__ file such as __init__.py and __init__.js
+	        	if(FileUtil.getFileName(anyfile.getPath(),false).equals("__init__"))
+	        	{
 
+	        		File pluginRootDirectory = new File(FileUtil.getDirectory(anyfile.getAbsolutePath()));	        	
+	        		PluginDescriptor newPlugin = new PluginDescriptor(pluginRootDirectory);
+	        		//check if it is a valid plugin descriptor
+	        		if(newPlugin.isDescriptorLoaded() && newPlugin.isScriptPlugin())
+	        		{
+	            		PluginDescriptor engineClassDescriptor = PluginDescriptor.getPlugin(newPlugins,newPlugin.getScriptEngineClassname());
+	            		if(engineClassDescriptor == null)
+	            		{
+	            			System.err.println("Script Engine Plugin can not be found:" + newPlugin.getScriptEngineClassname());
+	            		}
+	            		else
+	            		{
+	            			//check if the plugin class has PluginScriptEngine interface
+	            			Class<? extends Plugin> pluginClass = engineClassDescriptor.getPluginClass();
+	            			if(PluginScriptEngine.class.isAssignableFrom( pluginClass) )
+	            			{
+	            				newPlugin.setPluginClass(pluginClass);
+			            		
+			            		if(!PluginDescriptor.existInList(newPlugins,newPlugin))
+			                	{
+			                		newPlugins.add(newPlugin);
+			                	}
+		            		}
+	            		}
+	            		
+	        		}
+	            		
+	        		
+	        	}
+	    	}
+	    	catch(Exception e)
+	    	{
+	    		
+	    	}
+        }
+		
+        
         // sort list
         Collections.sort(newPlugins, PluginNameSorter.instance);
 

--- a/icy/plugin/PluginLoader.java
+++ b/icy/plugin/PluginLoader.java
@@ -331,6 +331,7 @@ public class PluginLoader
             }
         }
         
+        //load plugin write in script
 	    File pluginsDir = new File(PLUGIN_PATH);
 	    for(File anyfile:FileUtil.getFiles(pluginsDir, null, true, false, true))
 	    {

--- a/icy/plugin/abstract_/Plugin.java
+++ b/icy/plugin/abstract_/Plugin.java
@@ -20,6 +20,8 @@ package icy.plugin.abstract_;
 
 import icy.file.FileUtil;
 import icy.gui.frame.IcyFrame;
+import icy.gui.frame.IcyFrameAdapter;
+import icy.gui.frame.IcyFrameEvent;
 import icy.gui.viewer.Viewer;
 import icy.image.IcyBufferedImage;
 import icy.image.ImageUtil;
@@ -41,6 +43,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.HashMap;
 
 import javax.swing.ImageIcon;
 
@@ -53,6 +56,7 @@ import javax.swing.ImageIcon;
  */
 public abstract class Plugin
 {
+	
     public static Plugin getPlugin(ArrayList<Plugin> list, String className)
     {
         for (Plugin plugin : list)
@@ -62,6 +66,7 @@ public abstract class Plugin
         return null;
     }
 
+    public static HashMap<PluginDescriptor, ArrayList<IcyFrame>> openedFramesMap = new HashMap<PluginDescriptor, ArrayList<IcyFrame>>();
     private final PluginDescriptor descriptor;
 
     public Plugin()
@@ -139,6 +144,31 @@ public abstract class Plugin
 
     public void addIcyFrame(final IcyFrame frame)
     {
+    	//Add the frame to openedFrameMap for popup menu generation
+    	//FIXME: Not all plugin add frame use this function
+    	if(openedFramesMap.containsKey(descriptor)){
+    		openedFramesMap.get(descriptor).add(frame);
+    	}
+    	else{
+    		ArrayList<IcyFrame> fl = new ArrayList<IcyFrame>();
+    		fl.add(frame);
+    		openedFramesMap.put(descriptor, fl);
+    	}	
+    	frame.addFrameListener(new IcyFrameAdapter()
+        {
+            // called when frame is closed
+            @Override
+            public void icyFrameClosed(IcyFrameEvent e)
+            {
+    	    	if(openedFramesMap.containsKey(descriptor)){
+		    		openedFramesMap.get(descriptor).remove(frame);
+		    		//remove the empty item
+		    		if(openedFramesMap.get(descriptor).size()<=0)
+		    			openedFramesMap.remove(descriptor);
+		    	}
+            }
+        });
+    	
         frame.addToMainDesktopPane();
     }
 

--- a/icy/plugin/abstract_/Plugin.java
+++ b/icy/plugin/abstract_/Plugin.java
@@ -20,8 +20,6 @@ package icy.plugin.abstract_;
 
 import icy.file.FileUtil;
 import icy.gui.frame.IcyFrame;
-import icy.gui.frame.IcyFrameAdapter;
-import icy.gui.frame.IcyFrameEvent;
 import icy.gui.viewer.Viewer;
 import icy.image.IcyBufferedImage;
 import icy.image.ImageUtil;
@@ -62,11 +60,11 @@ public abstract class Plugin
         for (Plugin plugin : list)
             if (plugin.getClass().getName().equals(className))
                 return plugin;
-
         return null;
     }
 
-    public static HashMap<PluginDescriptor, ArrayList<IcyFrame>> openedFramesMap = new HashMap<PluginDescriptor, ArrayList<IcyFrame>>();
+    //set to final field enables safely read through non-synchronized methods
+    public final static HashMap<String, ArrayList<IcyFrame>> openedFramesMap = new HashMap<String, ArrayList<IcyFrame>>();
     private final PluginDescriptor descriptor;
 
     public Plugin()
@@ -145,30 +143,6 @@ public abstract class Plugin
     public void addIcyFrame(final IcyFrame frame)
     {
     	//Add the frame to openedFrameMap for popup menu generation
-    	//FIXME: Not all plugin add frame use this function
-    	if(openedFramesMap.containsKey(descriptor)){
-    		openedFramesMap.get(descriptor).add(frame);
-    	}
-    	else{
-    		ArrayList<IcyFrame> fl = new ArrayList<IcyFrame>();
-    		fl.add(frame);
-    		openedFramesMap.put(descriptor, fl);
-    	}	
-    	frame.addFrameListener(new IcyFrameAdapter()
-        {
-            // called when frame is closed
-            @Override
-            public void icyFrameClosed(IcyFrameEvent e)
-            {
-    	    	if(openedFramesMap.containsKey(descriptor)){
-		    		openedFramesMap.get(descriptor).remove(frame);
-		    		//remove the empty item
-		    		if(openedFramesMap.get(descriptor).size()<=0)
-		    			openedFramesMap.remove(descriptor);
-		    	}
-            }
-        });
-    	
         frame.addToMainDesktopPane();
     }
 

--- a/icy/plugin/interface_/PluginScriptEngine.java
+++ b/icy/plugin/interface_/PluginScriptEngine.java
@@ -1,7 +1,29 @@
+/*
+ * Copyright 2010-2013 Institut Pasteur.
+ * 
+ * This file is part of Icy.
+ * 
+ * Icy is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Icy is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Icy. If not, see <http://www.gnu.org/licenses/>.
+ */
 package icy.plugin.interface_;
 
 import java.io.File;
-
+/**
+ * This interface used to support plugin write in script.
+ * 
+ * @author Will Ouyang
+ */
 public interface PluginScriptEngine {
 	public void eval(String scripts);
 	public void evalFile(File file);

--- a/icy/plugin/interface_/PluginScriptEngine.java
+++ b/icy/plugin/interface_/PluginScriptEngine.java
@@ -1,0 +1,9 @@
+package icy.plugin.interface_;
+
+import java.io.File;
+
+public interface PluginScriptEngine {
+	public void eval(String scripts);
+	public void evalFile(File file);
+	
+}

--- a/plugins/kernel/scriptengine/JavascriptEngine.java
+++ b/plugins/kernel/scriptengine/JavascriptEngine.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2010-2013 Institut Pasteur.
+ * 
+ * This file is part of Icy.
+ * 
+ * Icy is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Icy is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Icy. If not, see <http://www.gnu.org/licenses/>.
+ */
 package plugins.kernel.scriptengine;
 
 import java.io.BufferedInputStream;
@@ -20,6 +38,11 @@ import icy.plugin.abstract_.PluginActionable;
 import icy.plugin.interface_.PluginScriptEngine;
 import icy.script.ScriptEditor;
 
+/**
+ * This class is used to run plugin write in script.
+ * 
+ * @author Will Ouyang & Tprovoost
+ */
 public class JavascriptEngine extends PluginActionable implements PluginScriptEngine {
 	private ScriptableObject scriptable;
 	private String lastFileName = "";

--- a/plugins/kernel/scriptengine/JavascriptEngine.java
+++ b/plugins/kernel/scriptengine/JavascriptEngine.java
@@ -1,0 +1,169 @@
+package plugins.kernel.scriptengine;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import sun.org.mozilla.javascript.internal.Context;
+import sun.org.mozilla.javascript.internal.EvaluatorException;
+import sun.org.mozilla.javascript.internal.ImporterTopLevel;
+import sun.org.mozilla.javascript.internal.NativeJavaObject;
+import sun.org.mozilla.javascript.internal.RhinoException;
+import sun.org.mozilla.javascript.internal.Script;
+import sun.org.mozilla.javascript.internal.ScriptableObject;
+
+import icy.file.FileUtil;
+import icy.plugin.PluginLoader;
+import icy.plugin.abstract_.PluginActionable;
+import icy.plugin.interface_.PluginScriptEngine;
+import icy.script.ScriptEditor;
+
+public class JavascriptEngine extends PluginActionable implements PluginScriptEngine {
+	private ScriptableObject scriptable;
+	private String lastFileName = "";
+	public JavascriptEngine()
+	{
+		super();
+		//init the script engine
+		Context context = Context.enter();
+		context.setApplicationClassLoader(PluginLoader.getLoader());
+		scriptable = new IcyImporterTopLevel(context);
+		Context.exit();		
+					 
+	}
+	@Override
+	public void run() {		
+		new ScriptEditor();
+	}
+
+	public void evalFile(File file) throws EvaluatorException
+	{
+		if(file == null)
+			return;
+		if (!file.exists() || !file.isFile())
+		{
+			throw new EvaluatorException("The script file could not be found, please check if it is correctly saved on the disk.", file.getAbsolutePath(), -1);
+		}
+		
+		this.lastFileName = file.getAbsolutePath();
+		byte[] bytes = null;
+		try
+		{
+			BufferedInputStream bis = new BufferedInputStream(new FileInputStream(file));
+			bytes = new byte[bis.available()];
+			bis.read(bytes);
+			bis.close();
+			((IcyImporterTopLevel)scriptable).setcwd(FileUtil.getDirectory(file.getPath()));
+		} catch (IOException e1)
+		{
+			throw new EvaluatorException(e1.getMessage(), file.getAbsolutePath(), -1);
+		}
+		String scripts = new String(bytes);
+		eval(scripts);
+	
+	}
+	public void eval(String scripts) throws EvaluatorException
+	{
+		Context context = Context.enter();
+		context.setApplicationClassLoader(PluginLoader.getLoader());
+		try
+		{
+			System.out.println("excuting javascript...");
+			Script script = context.compileString(scripts, "script", 0, null);
+			script.exec(context, scriptable);
+			System.out.println("done!");
+		} catch(Exception e)
+		{
+			System.out.println(e.toString());
+		} finally
+		{
+			Context.exit();
+		}
+	}	
+	class IcyImporterTopLevel extends ImporterTopLevel
+	{
+
+		private String cwd = "";
+		public IcyImporterTopLevel(Context context)
+		{
+			super(context);
+			String[] names = { "println", "print", "eval", "getcwd" };
+			defineFunctionProperties(names, IcyImporterTopLevel.class, ScriptableObject.DONTENUM);
+		}
+
+		public void println(Object o)
+		{
+			System.out.print(Context.toString(o) + "\n");
+		}
+
+		public void print(Object o)
+		{
+			System.out.print(Context.toString(o));
+		}
+		public String getcwd()
+		{
+			return cwd;
+		}
+		public  void setcwd(String s)
+		{
+			cwd =s;
+		}
+		public void eval(Object o) throws  FileNotFoundException,EvaluatorException
+		{
+			File f;
+			if (o instanceof NativeJavaObject && ((NativeJavaObject) o).unwrap() instanceof File)
+				f = (File) ((NativeJavaObject) o).unwrap();
+			else if (o instanceof String)
+			{
+				String s = (String) o;
+				f = new File(s);
+				if (!f.exists() && !s.contains(File.separator))
+				{
+					if (!s.endsWith(".js"))
+						s += ".js";
+					s = FileUtil.getDirectory(lastFileName) + File.separator + s;
+					f = new File(s);
+				}
+			} else
+			{
+				// getErrorWriter().write("Argument must be a file of a string.");
+				throw new FileNotFoundException("Argument must be a file of a string.");
+			}
+			BufferedInputStream bis = new BufferedInputStream(new FileInputStream(f));
+			byte[] bytes = null;
+			try
+			{
+				bytes = new byte[bis.available()];
+				bis.read(bytes);
+				bis.close();
+			} catch (IOException e1)
+			{
+				// getErrorWriter().write(e1.getMessage());
+			}
+			String s = new String(bytes);
+			Context context = Context.enter();
+			context.setApplicationClassLoader(PluginLoader.getLoader());
+			try
+			{
+				Script script = context.compileString(s, "script", 0, null);
+				script.exec(context, scriptable);
+			} catch (EvaluatorException e)
+			{
+				// getErrorWriter().write(e.getMessage());
+				throw new EvaluatorException(e.getMessage(), e.sourceName(),  e.columnNumber());
+			} catch (RhinoException e3)
+			{
+				// getErrorWriter().write(e3.getMessage());
+				throw new EvaluatorException(e3.getMessage(), e3.sourceName(),  e3.columnNumber());
+			} finally
+			{
+				Context.exit();
+			}
+		}
+	}
+	
+}	
+
+


### PR DESCRIPTION
Hi everyone,

Recently, I am thinking about add script plugin support to Icy. The motivations are:
1. Icy supports Javascript, Python and more in the future, but no script engine interface established.
2. Supporting plugins in script will change the way of developing, it will ease our developing experience and boost the speed. We now have ScriptEditor with autocomplete and highlighting, why should we use eclipse.
3. ScriptEditor can write script easily and why should we run it in the editor? When the develop is done, we only want to click a button and run it just like other plugins in Icy. Native script plugin support will be more elegant for user to run.
4. Script can be used to do some automation like macro, and also can be used to build actionable plugin, like this one [https://github.com/Icy-imaging/Icy-Kernel/issues/472] by Timothée Lecomte.

So I made this demonstration, and send this pull request to remind you,  and you don't have to merge my code but I hope you can have a try.
The idea is that, script plugin is almost the same with normal plugin in Icy, it can be compressed in to a zip package. And unzip it in the "plugins" directory when installed, so every script is a directory with some specific name, and in the directory there should at least a xml file like normal plugin and a startup script with specific name like "__init__.py" or "__init__.js", To run the plugin, we should define a script engine interface, so script engine plugins be used, every script plugin store its script engine plugin class name in xml file. When icy started, it checks all the directory to find directory with "__init__.*" file and the corresponding xml file and try to load it as pluginDescriptor, and  store it if valid. In the pluginDescriptor, the plugin class is set to the script engine's plugin class. Then if we click on the plugin icon, the script engine will be created and excute the startup script.

So, the differences between a normal plugin and a script plugin is that it contains a "__init__*" file rather than a jar file, a script plugin also contain an additional node  in xml to define which script engine should be used to run the script.

Here we got a example script plugin, you can search online plugin repository for "PyPluginTest", and download it, ignore the error message. After download, you will get a file "plugins/oeway/pyplugintest.jar", delete the xml file in the same directory, and rename the jar file to "pyplugintest.zip" and unzip it to the same directory, and we will get a script plugin with GUI. 
It startup file is in Javascript, when it starts, it build a Python Interpreter to run a simple python plugin with EzPlug by Timothée Lecomte.It runs like this:

![scriptplugindemonstration](https://f.cloud.github.com/assets/478667/1452621/b01600b6-42d8-11e3-97a3-94e726671934.png)


If we want to integrate this in the future version, the plugin installer, updater and other also the website should make some change.
Feel free to check out and try it.
