### PR TITLE
Filter out Jython classes when reloading the plugins

### DIFF
--- a/icy/plugin/PluginLoader.java
+++ b/icy/plugin/PluginLoader.java
@@ -101,6 +101,7 @@ public class PluginLoader
 
     public final static String PLUGIN_PACKAGE = "plugins";
     public final static String PLUGIN_PATH = "plugins";
+    public final static String JYTHON_CLASSES_SUFFIX = "$py";
 
     /**
      * static class
@@ -281,6 +282,10 @@ public class PluginLoader
             // we only want to load classes from 'plugins' package
             if (!className.startsWith(PLUGIN_PACKAGE))
                 continue;
+            
+            // we do not want to reload Jython classes, that ends with "$py"
+            if (className.endsWith(JYTHON_CLASSES_SUFFIX))
+            	continue;
 
             // no need to complete loading...
             if (processor.hasWaitingTasks())


### PR DESCRIPTION
This prevents the Console from being flooded with messages such as:
Class 'plugins.tlecomte.jythonForIcy.Lib.re$py' cannot be loaded :
Required class 'plugins.tlecomte.jythonForIcy.Lib.re$py (wrong name:
re$py)' not found.
