### PR TITLE
Searchbar

### DIFF
--- a/icy/gui/menu/search/SearchBar.java
+++ b/icy/gui/menu/search/SearchBar.java
@@ -417,7 +417,9 @@ public class SearchBar extends IcyTextField implements SearchEngineListener
         if (initialized)
             resultsPanel.searchStarted();
         
+        // make sure the animation timer for the busy icon is stopped
         busyPainterTimer.cancel();
+        // ... and restart it
         busyPainterTimer = new Timer("Search animation timer");
         busyPainterTimer.scheduleAtFixedRate(new TimerTask()
         {
@@ -445,6 +447,7 @@ public class SearchBar extends IcyTextField implements SearchEngineListener
     @Override
     public void searchCompleted(SearchEngine source)
     {
+    	// stop the animation timer for the rotating busy icon
     	busyPainterTimer.cancel();
     	
         // for the busy loop animation


### PR DESCRIPTION
Hi Stef !

This pull request does two things about the busy icon in the searchbar:
- the animation timer is only started when a search starts, and is stopped when the search finishes. This avoids having a timer constantly firing... (Ideally having no timer firing would be great to save battery on a laptop, and I guess it can also help for users of Icy on small machines  - I was almsot crying when I tried using Icy on my eeepc !)
- Improve the look of the busy icon by increasing its rate to 50Hz and decreasing the dot size.

These commits are pretty safe, I think you can safely pull them. Thanks !
