### PR TITLE
Taskframemanager deepsleep

### DIFF
--- a/icy/gui/main/TaskFrameManager.java
+++ b/icy/gui/main/TaskFrameManager.java
@@ -141,13 +141,22 @@ public class TaskFrameManager
     }
     
     void startAnimation() {
+    	// make sure previous timer is stopped
     	animationTimer.cancel();
+    	// start a new Timer
     	animationTimer = new Timer("TaskFrame animation timer");
     	animationTimer.scheduleAtFixedRate(new TimerTask()
     	{
 			@Override
 			public void run() {
 				animateFrames();
+
+		        // stop the animation timer if there is no more TaskFrames
+				synchronized (taskFrameInfos) {
+			        if (taskFrameInfos.isEmpty()) {
+			        	cancel();
+			        }
+				}
 			}
     	}, ANIMATION_DELAY, ANIMATION_PERIOD);
     }


### PR DESCRIPTION
Hi Stef,

These commits makes the TaskFrameManager use a Timer instead of a Thread. This allows to stop the timer when there is no TaskFrame, which is a good thing I think....

By the way, I believe I fixed a possible a threading problem in commit      34b0ad4.

I tried to split the changes in simple commits to make sure I did not make bad mistakes ;)
