### PR TITLE
(IcyExceptionHandler) Locate origin of exceptions in plugin more accurately

### DIFF
--- a/icy/plugin/PluginDescriptor.java
+++ b/icy/plugin/PluginDescriptor.java
@@ -1521,4 +1521,19 @@ public class PluginDescriptor implements XMLPersistent
     {
         return getClassName().hashCode() ^ getVersion().hashCode();
     }
+
+    /**
+     * Tells if this plugin descriptor comes from a plugin downloaded
+     * from an online repository.
+     *
+     * If this plugin descriptor comes from a plugin bundle (i.e. several
+     * classes extending Plugin in a single JAR), only the one whose classname
+     * is declared online will return True.
+     *
+     * @return True if the plugin comes from a web repository.
+     */
+    public boolean isOnline()
+    {
+        return (getJarUrl() != null && getJarUrl().length() > 0);
+    }
 }


### PR DESCRIPTION
Dear Stephane,

This is a proposed improvement for the IcyExceptionHandler.

As you noticed, I do not receive some of the bug reports for errors happening in the Script-Editor. They are not displayed in the bug reports list on the plugin management page. This is because Icy failed to associate the stack trace with the Script-Editor plugin.

To address that, I have first submitted a Plugin that reproduces the problem. It is named "Generate a bug in a plugin bundle", and it is flagged as beta. It generates a NullPointerException in a thread, from a class extending Plugin but that is not the one declared on the plugin management page.

Before this pull request, Icy fails to associate the error with the plugin, and it reports only to the author found with the package name.

With this pull request, Icy successfully associates the error with the plugin.

Here is how it works;
First it finds the JAR the class comes from, 
Then it finds the right plugin that was declared on the repository for this JAR.

I hope this is clean enough for merging !

Thanks,

Timothée
