### PR TITLE
Fixed round-off issue in ROI3DStack.contains()

### DIFF
--- a/plugins/kernel/roi/roi3d/ROI3DStack.java
+++ b/plugins/kernel/roi/roi3d/ROI3DStack.java
@@ -582,7 +582,7 @@ public class ROI3DStack<R extends ROI2D> extends ROI3D implements ROIListener, O
     @Override
     public boolean contains(double x, double y, double z)
     {
-        final R roi2d = getSlice((int) z);
+        final R roi2d = getSlice((int) Math.floor(z));
 
         if (roi2d != null)
             return roi2d.contains(x, y);


### PR DESCRIPTION
writing `(int) z` poses issues when checking lower bounds.
For instance, let us assume the ROI3D starts at z=0. Here a call to `contains(anyX, anyY, -0.1)` will return true because -0.1 is rounded off to 0, while it should return false.
